### PR TITLE
Allow clear dates to clear partially entered dates

### DIFF
--- a/src/components/DateInput.jsx
+++ b/src/components/DateInput.jsx
@@ -10,6 +10,7 @@ const propTypes = forbidExtraProps({
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
   inputValue: PropTypes.string,
+  userInputValue: PropTypes.string,
   screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -18,6 +19,7 @@ const propTypes = forbidExtraProps({
   showCaret: PropTypes.bool,
 
   onChange: PropTypes.func,
+  onUserInputChange: PropTypes.func,
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
   onKeyDownTab: PropTypes.func,
@@ -33,6 +35,7 @@ const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
   inputValue: '',
+  userInputValue: '',
   screenReaderMessage: '',
   focused: false,
   disabled: false,
@@ -41,6 +44,7 @@ const defaultProps = {
   showCaret: false,
 
   onChange() {},
+  onUserInputChange() {},
   onFocus() {},
   onKeyDownShiftTab() {},
   onKeyDownTab() {},
@@ -56,7 +60,6 @@ export default class DateInput extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      dateString: '',
       isTouchDevice: false,
     };
 
@@ -70,9 +73,7 @@ export default class DateInput extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (!this.props.displayValue && nextProps.displayValue) {
-      this.setState({
-        dateString: '',
-      });
+      nextProps.onUserInputChange('');
     }
   }
 
@@ -89,7 +90,7 @@ export default class DateInput extends React.Component {
   }
 
   onChange(e) {
-    const { onChange, onKeyDownQuestionMark } = this.props;
+    const { onChange, onKeyDownQuestionMark, onUserInputChange } = this.props;
     const dateString = e.target.value;
 
     // In Safari, onKeyDown does not consistently fire ahead of onChange. As a result, we need to
@@ -98,7 +99,7 @@ export default class DateInput extends React.Component {
     if (dateString[dateString.length - 1] === '?') {
       onKeyDownQuestionMark(e);
     } else {
-      this.setState({ dateString });
+      onUserInputChange(dateString);
       onChange(dateString);
     }
   }
@@ -130,7 +131,6 @@ export default class DateInput extends React.Component {
 
   render() {
     const {
-      dateString,
       isTouchDevice: isTouch,
     } = this.state;
     const {
@@ -138,6 +138,7 @@ export default class DateInput extends React.Component {
       placeholder,
       displayValue,
       inputValue,
+      userInputValue,
       screenReaderMessage,
       focused,
       showCaret,
@@ -147,8 +148,8 @@ export default class DateInput extends React.Component {
       readOnly,
     } = this.props;
 
-    const displayText = displayValue || inputValue || dateString || placeholder || '';
-    const value = inputValue || displayValue || dateString || '';
+    const displayText = displayValue || inputValue || userInputValue || placeholder || '';
+    const value = inputValue || displayValue || userInputValue || '';
     const screenReaderMessageId = `DateInput__screen-reader-message-${id}`;
 
     return (

--- a/src/components/DateRangePickerInput.jsx
+++ b/src/components/DateRangePickerInput.jsx
@@ -26,6 +26,8 @@ const propTypes = forbidExtraProps({
   onEndDateFocus: PropTypes.func,
   onStartDateChange: PropTypes.func,
   onEndDateChange: PropTypes.func,
+  onStartDateUserInputChange: PropTypes.func,
+  onEndDateUserInputChange: PropTypes.func,
   onStartDateShiftTab: PropTypes.func,
   onEndDateTab: PropTypes.func,
   onClearDates: PropTypes.func,
@@ -34,8 +36,10 @@ const propTypes = forbidExtraProps({
 
   startDate: PropTypes.string,
   startDateValue: PropTypes.string,
+  startDateUserInputValue: PropTypes.string,
   endDate: PropTypes.string,
   endDateValue: PropTypes.string,
+  endDateUserInputValue: PropTypes.string,
 
   isStartDateFocused: PropTypes.bool,
   isEndDateFocused: PropTypes.bool,
@@ -68,6 +72,8 @@ const defaultProps = {
   onEndDateFocus() {},
   onStartDateChange() {},
   onEndDateChange() {},
+  onStartDateUserInputChange() {},
+  onEndDateUserInputChange() {},
   onStartDateShiftTab() {},
   onEndDateTab() {},
   onClearDates() {},
@@ -76,8 +82,10 @@ const defaultProps = {
 
   startDate: '',
   startDateValue: '',
+  startDateUserInputValue: '',
   endDate: '',
   endDateValue: '',
+  endDateUserInputValue: '',
 
   isStartDateFocused: false,
   isEndDateFocused: false,
@@ -128,19 +136,23 @@ export default class DateRangePickerInput extends React.Component {
     const {
       startDate,
       startDateValue,
+      startDateUserInputValue,
       startDateId,
       startDatePlaceholderText,
       screenReaderMessage,
       isStartDateFocused,
       onStartDateChange,
+      onStartDateUserInputChange,
       onStartDateFocus,
       onStartDateShiftTab,
       endDate,
       endDateValue,
+      endDateUserInputValue,
       endDateId,
       endDatePlaceholderText,
       isEndDateFocused,
       onEndDateChange,
+      onEndDateUserInputChange,
       onEndDateFocus,
       onEndDateTab,
       onArrowDown,
@@ -164,6 +176,8 @@ export default class DateRangePickerInput extends React.Component {
     const arrowIcon = customArrowIcon || (isRTL ? <LeftArrow /> : <RightArrow />);
     const closeIcon = customCloseIcon || (<CloseButton />);
     const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
+    const isClearDatesHidden =
+      !(startDate || endDate || startDateUserInputValue || endDateUserInputValue);
 
     return (
       <div
@@ -189,6 +203,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={startDatePlaceholderText}
           displayValue={startDate}
           inputValue={startDateValue}
+          userInputValue={startDateUserInputValue}
           screenReaderMessage={screenReaderText}
           focused={isStartDateFocused}
           isFocused={isFocused}
@@ -198,6 +213,7 @@ export default class DateRangePickerInput extends React.Component {
           showCaret={showCaret}
 
           onChange={onStartDateChange}
+          onUserInputChange={onStartDateUserInputChange}
           onFocus={onStartDateFocus}
           onKeyDownShiftTab={onStartDateShiftTab}
           onKeyDownArrowDown={onArrowDown}
@@ -217,6 +233,7 @@ export default class DateRangePickerInput extends React.Component {
           placeholder={endDatePlaceholderText}
           displayValue={endDate}
           inputValue={endDateValue}
+          userInputValue={endDateUserInputValue}
           screenReaderMessage={screenReaderText}
           focused={isEndDateFocused}
           isFocused={isFocused}
@@ -226,6 +243,7 @@ export default class DateRangePickerInput extends React.Component {
           showCaret={showCaret}
 
           onChange={onEndDateChange}
+          onUserInputChange={onEndDateUserInputChange}
           onFocus={onEndDateFocus}
           onKeyDownTab={onEndDateTab}
           onKeyDownArrowDown={onArrowDown}
@@ -237,7 +255,7 @@ export default class DateRangePickerInput extends React.Component {
             type="button"
             aria-label={phrases.clearDates}
             className={cx('DateRangePickerInput__clear-dates', {
-              'DateRangePickerInput__clear-dates--hide': !(startDate || endDate),
+              'DateRangePickerInput__clear-dates--hide': isClearDatesHidden,
               'DateRangePickerInput__clear-dates--hover': isClearDatesHovered,
             })}
             onMouseEnter={this.onClearDatesMouseEnter}

--- a/src/components/DateRangePickerInputController.jsx
+++ b/src/components/DateRangePickerInputController.jsx
@@ -112,11 +112,17 @@ const defaultProps = {
 export default class DateRangePickerInputController extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      startDateUserInputValue: '',
+      endDateUserInputValue: '',
+    };
 
     this.onClearFocus = this.onClearFocus.bind(this);
     this.onStartDateChange = this.onStartDateChange.bind(this);
+    this.onStartDateUserInputChange = this.onStartDateUserInputChange.bind(this);
     this.onStartDateFocus = this.onStartDateFocus.bind(this);
     this.onEndDateChange = this.onEndDateChange.bind(this);
+    this.onEndDateUserInputChange = this.onEndDateUserInputChange.bind(this);
     this.onEndDateFocus = this.onEndDateFocus.bind(this);
     this.clearDates = this.clearDates.bind(this);
   }
@@ -165,6 +171,12 @@ export default class DateRangePickerInputController extends React.Component {
     }
   }
 
+  onEndDateUserInputChange(endDateUserInputValue) {
+    this.setState({
+      endDateUserInputValue,
+    });
+  }
+
   onStartDateChange(startDateString) {
     const startDate = toMomentObject(startDateString, this.getDisplayFormat());
 
@@ -192,6 +204,12 @@ export default class DateRangePickerInputController extends React.Component {
     }
   }
 
+  onStartDateUserInputChange(startDateUserInputValue) {
+    this.setState({
+      startDateUserInputValue,
+    });
+  }
+
   getDisplayFormat() {
     const { displayFormat } = this.props;
     return typeof displayFormat === 'string' ? displayFormat : displayFormat();
@@ -207,6 +225,8 @@ export default class DateRangePickerInputController extends React.Component {
 
   clearDates() {
     const { onDatesChange, reopenPickerOnClearDates, onFocusChange } = this.props;
+    this.onStartDateUserInputChange('');
+    this.onEndDateUserInputChange('');
     onDatesChange({ startDate: null, endDate: null });
     if (reopenPickerOnClearDates) {
       onFocusChange(START_DATE);
@@ -240,6 +260,11 @@ export default class DateRangePickerInputController extends React.Component {
       isRTL,
     } = this.props;
 
+    const {
+      startDateUserInputValue,
+      endDateUserInputValue,
+    } = this.state;
+
     const startDateString = this.getDateString(startDate);
     const startDateValue = toISODateString(startDate);
     const endDateString = this.getDateString(endDate);
@@ -249,11 +274,13 @@ export default class DateRangePickerInputController extends React.Component {
       <DateRangePickerInput
         startDate={startDateString}
         startDateValue={startDateValue}
+        startDateUserInputValue={startDateUserInputValue}
         startDateId={startDateId}
         startDatePlaceholderText={startDatePlaceholderText}
         isStartDateFocused={isStartDateFocused}
         endDate={endDateString}
         endDateValue={endDateValue}
+        endDateUserInputValue={endDateUserInputValue}
         endDateId={endDateId}
         endDatePlaceholderText={endDatePlaceholderText}
         isEndDateFocused={isEndDateFocused}
@@ -268,9 +295,11 @@ export default class DateRangePickerInputController extends React.Component {
         customCloseIcon={customCloseIcon}
         phrases={phrases}
         onStartDateChange={this.onStartDateChange}
+        onStartDateUserInputChange={this.onStartDateUserInputChange}
         onStartDateFocus={this.onStartDateFocus}
         onStartDateShiftTab={this.onClearFocus}
         onEndDateChange={this.onEndDateChange}
+        onEndDateUserInputChange={this.onEndDateUserInputChange}
         onEndDateFocus={this.onEndDateFocus}
         onEndDateTab={this.onClearFocus}
         showClearDates={showClearDates}

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -73,6 +73,7 @@ const defaultProps = {
   onPrevMonthClick() {},
   onNextMonthClick() {},
   onClose() {},
+  onDateChange() {},
 
   // month presentation and interaction related props
   renderMonth: null,
@@ -97,6 +98,7 @@ export default class SingleDatePicker extends React.Component {
     this.isTouchDevice = false;
 
     this.state = {
+      userInputValue: '',
       dayPickerContainerStyles: {},
       isDayPickerFocused: false,
       isInputFocused: false,
@@ -106,6 +108,7 @@ export default class SingleDatePicker extends React.Component {
     this.onDayPickerBlur = this.onDayPickerBlur.bind(this);
 
     this.onChange = this.onChange.bind(this);
+    this.onUserInputChange = this.onUserInputChange.bind(this);
     this.onFocus = this.onFocus.bind(this);
     this.onClearFocus = this.onClearFocus.bind(this);
     this.clearDate = this.clearDate.bind(this);
@@ -180,6 +183,12 @@ export default class SingleDatePicker extends React.Component {
     }
   }
 
+  onUserInputChange(userInputValue) {
+    this.setState({
+      userInputValue,
+    });
+  }
+
   onClearFocus() {
     const { startDate, endDate, focused, onFocusChange, onClose } = this.props;
     if (!focused) return;
@@ -238,6 +247,7 @@ export default class SingleDatePicker extends React.Component {
 
   clearDate() {
     const { onDateChange, reopenPickerOnClearDate, onFocusChange } = this.props;
+    this.onUserInputChange('');
     onDateChange(null);
     if (reopenPickerOnClearDate) {
       onFocusChange({ focused: true });
@@ -404,7 +414,7 @@ export default class SingleDatePicker extends React.Component {
       isRTL,
     } = this.props;
 
-    const { isInputFocused } = this.state;
+    const { userInputValue, isInputFocused } = this.state;
 
     const displayValue = this.getDateString(date);
     const inputValue = toISODateString(date);
@@ -429,7 +439,9 @@ export default class SingleDatePicker extends React.Component {
             customInputIcon={customInputIcon}
             displayValue={displayValue}
             inputValue={inputValue}
+            userInputValue={userInputValue}
             onChange={this.onChange}
+            onUserInputChange={this.onUserInputChange}
             onFocus={this.onFocus}
             onKeyDownShiftTab={this.onClearFocus}
             onKeyDownTab={this.onClearFocus}

--- a/src/components/SingleDatePickerInput.jsx
+++ b/src/components/SingleDatePickerInput.jsx
@@ -15,6 +15,7 @@ const propTypes = forbidExtraProps({
   placeholder: PropTypes.string, // also used as label
   displayValue: PropTypes.string,
   inputValue: PropTypes.string,
+  userInputValue: PropTypes.string,
   screenReaderMessage: PropTypes.string,
   focused: PropTypes.bool,
   isFocused: PropTypes.bool, // describes actual DOM focus
@@ -28,6 +29,7 @@ const propTypes = forbidExtraProps({
   customInputIcon: PropTypes.node,
   isRTL: PropTypes.bool,
   onChange: PropTypes.func,
+  onUserInputChange: PropTypes.func,
   onClearDate: PropTypes.func,
   onFocus: PropTypes.func,
   onKeyDownShiftTab: PropTypes.func,
@@ -42,6 +44,7 @@ const defaultProps = {
   placeholder: 'Select Date',
   displayValue: '',
   inputValue: '',
+  userInputValue: '',
   screenReaderMessage: '',
   focused: false,
   isFocused: false,
@@ -56,6 +59,7 @@ const defaultProps = {
   isRTL: false,
 
   onChange() {},
+  onUserInputChange() {},
   onClearDate() {},
   onFocus() {},
   onKeyDownShiftTab() {},
@@ -96,6 +100,7 @@ export default class SingleDatePickerInput extends React.Component {
       placeholder,
       displayValue,
       inputValue,
+      userInputValue,
       focused,
       isFocused,
       disabled,
@@ -107,6 +112,7 @@ export default class SingleDatePickerInput extends React.Component {
       phrases,
       onClearDate,
       onChange,
+      onUserInputChange,
       onFocus,
       onKeyDownShiftTab,
       onKeyDownTab,
@@ -120,6 +126,7 @@ export default class SingleDatePickerInput extends React.Component {
     const inputIcon = customInputIcon || (<CalendarIcon />);
     const closeIcon = customCloseIcon || (<CloseButton />);
     const screenReaderText = screenReaderMessage || phrases.keyboardNavigationInstructions;
+    const isClearDateHidden = !(displayValue || userInputValue);
 
     return (
       <div
@@ -143,6 +150,7 @@ export default class SingleDatePickerInput extends React.Component {
           placeholder={placeholder} // also used as label
           displayValue={displayValue}
           inputValue={inputValue}
+          userInputValue={userInputValue}
           screenReaderMessage={screenReaderText}
           focused={focused}
           isFocused={isFocused}
@@ -151,6 +159,7 @@ export default class SingleDatePickerInput extends React.Component {
           readOnly={readOnly}
           showCaret={showCaret}
           onChange={onChange}
+          onUserInputChange={onUserInputChange}
           onFocus={onFocus}
           onKeyDownShiftTab={onKeyDownShiftTab}
           onKeyDownTab={onKeyDownTab}
@@ -161,7 +170,7 @@ export default class SingleDatePickerInput extends React.Component {
           <button
             type="button"
             className={cx('SingleDatePickerInput__clear-date', {
-              'SingleDatePickerInput__clear-date--hide': !displayValue,
+              'SingleDatePickerInput__clear-date--hide': isClearDateHidden,
               'SingleDatePickerInput__clear-date--hover': isClearDateHovered,
             })}
             aria-label={phrases.clearDate}

--- a/test/components/DateInput_spec.jsx
+++ b/test/components/DateInput_spec.jsx
@@ -52,13 +52,10 @@ describe('DateInput', () => {
         expect(wrapper.find('input').props().value).to.equal(DISPLAY_VALUE);
       });
 
-      it('has value === state.dateString if neither inputValue or displayValue are passed in',
+      it('has value === props.userInputValue if neither inputValue or displayValue are passed in',
         () => {
           const DATE_STRING = 'foobar';
-          const wrapper = shallow(<DateInput id="date" />);
-          wrapper.setState({
-            dateString: DATE_STRING,
-          });
+          const wrapper = shallow(<DateInput id="date" userInputValue={DATE_STRING} />);
           expect(wrapper.find('input').props().value).to.equal(DATE_STRING);
         },
       );
@@ -178,10 +175,18 @@ describe('DateInput', () => {
 
   describe('#onChange', () => {
     const evt = { target: { value: 'foobar' } };
-    it('sets state.dateString to e.target.value', () => {
-      const wrapper = shallow(<DateInput id="date" />);
+    it('calls props.onUserInputChange once', () => {
+      const onUserInputChangeStub = sinon.stub();
+      const wrapper = shallow(<DateInput id="date" onUserInputChange={onUserInputChangeStub} />);
       wrapper.instance().onChange(evt);
-      expect(wrapper.state().dateString).to.equal('foobar');
+      expect(onUserInputChangeStub.callCount).to.equal(1);
+    });
+
+    it('calls props.onUserInputChange with e.target.value as arg', () => {
+      const onUserInputChangeStub = sinon.stub();
+      const wrapper = shallow(<DateInput id="date" onUserInputChange={onUserInputChangeStub} />);
+      wrapper.instance().onChange(evt);
+      expect(onUserInputChangeStub.getCall(0).args[0]).to.equal(evt.target.value);
     });
 
     it('calls props.onChange once', () => {

--- a/test/components/DateRangePickerInputController_spec.jsx
+++ b/test/components/DateRangePickerInputController_spec.jsx
@@ -69,6 +69,22 @@ describe('DateRangePickerInputController', () => {
       });
     });
 
+    it('calls onStartDateUserInputChange with empty string', () => {
+      const onStartDateUserInputChangeSpy =
+        sinon.spy(DateRangePickerInputController.prototype, 'onStartDateUserInputChange');
+      const wrapper = shallow(<DateRangePickerInputController />);
+      wrapper.instance().clearDates();
+      expect(onStartDateUserInputChangeSpy.getCall(0).args[0]).to.equal('');
+    });
+
+    it('calls onEndDateUserInputChange with empty string', () => {
+      const onEndDateUserInputChangeSpy =
+        sinon.spy(DateRangePickerInputController.prototype, 'onEndDateUserInputChange');
+      const wrapper = shallow(<DateRangePickerInputController />);
+      wrapper.instance().clearDates();
+      expect(onEndDateUserInputChangeSpy.getCall(0).args[0]).to.equal('');
+    });
+
     it('calls props.onDatesChange with arg { startDate: null, endDate: null }', () => {
       const onDatesChangeStub = sinon.stub();
       const wrapper = shallow(

--- a/test/components/DateRangePickerInput_spec.jsx
+++ b/test/components/DateRangePickerInput_spec.jsx
@@ -70,17 +70,29 @@ describe('DateRangePickerInput', () => {
             expect(wrapper.find('.DateRangePickerInput__clear-dates--hover')).to.have.lengthOf(0);
           });
 
-        it('has .DateRangePickerInput__clear-dates--hide class if there are no dates',
+        it('has .DateRangePickerInput__clear-dates--hide class if there are no dates and no user input',
           () => {
             const wrapper = shallow(
-              <DateRangePickerInput showClearDates startDate={null} endDate={null} />,
-            );
+              <DateRangePickerInput
+                showClearDates
+                startDate={null}
+                endDate={null}
+                startDateUserInputValue={null}
+                endDateUserInputValue={null}
+              />);
             expect(wrapper.find('.DateRangePickerInput__clear-dates--hide')).to.have.lengthOf(1);
           });
 
         it('does not have .DateRangePickerInput__clear-dates--hide class if there are dates',
           () => {
             const wrapper = shallow(<DateRangePickerInput showClearDates startDate="2016-07-13" />);
+            expect(wrapper.find('.DateRangePickerInput__clear-dates--hide')).to.have.lengthOf(0);
+          });
+
+        it('does not have .DateRangePickerInput__clear-dates--hide class if there is user input',
+          () => {
+            const wrapper = shallow(
+              <DateRangePickerInput showClearDates startDateUserInputValue="foobar" />);
             expect(wrapper.find('.DateRangePickerInput__clear-dates--hide')).to.have.lengthOf(0);
           });
       });

--- a/test/components/SingleDatePickerInput_spec.jsx
+++ b/test/components/SingleDatePickerInput_spec.jsx
@@ -46,9 +46,14 @@ describe('SingleDatePickerInput', () => {
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hover')).to.have.lengthOf(0);
         });
 
-      it('has .SingleDatePickerInput__clear-date--hide class if there is no date',
+      it('has .SingleDatePickerInput__clear-date--hide class if there is no date and no user input',
         () => {
-          const wrapper = shallow(<SingleDatePickerInput showClearDate displayValue={null} />);
+          const wrapper = shallow(
+            <SingleDatePickerInput
+              showClearDate
+              displayValue={null}
+              userInputValue={null}
+            />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(1);
         });
 
@@ -56,6 +61,13 @@ describe('SingleDatePickerInput', () => {
         () => {
           const wrapper =
             shallow(<SingleDatePickerInput showClearDate displayValue="2016-07-13" />);
+          expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
+        });
+
+      it('does not have .SingleDatePickerInput__clear-date--hide class if there is user input',
+        () => {
+          const wrapper =
+            shallow(<SingleDatePickerInput showClearDate userInputValue="foobar" />);
           expect(wrapper.find('.SingleDatePickerInput__clear-date--hide')).to.have.lengthOf(0);
         });
     });

--- a/test/components/SingleDatePicker_spec.jsx
+++ b/test/components/SingleDatePicker_spec.jsx
@@ -738,6 +738,13 @@ describe('SingleDatePicker', () => {
       });
     });
 
+    it('calls onUserInputChange with empty string', () => {
+      const onUserInputChangeSpy = sinon.spy(SingleDatePicker.prototype, 'onUserInputChange');
+      const wrapper = shallow(<SingleDatePicker />);
+      wrapper.instance().clearDate();
+      expect(onUserInputChangeSpy.getCall(0).args[0]).to.equal('');
+    });
+
     it('calls props.onDateChange with null date', () => {
       const onDateChangeStub = sinon.stub();
       const wrapper = shallow(


### PR DESCRIPTION
Addresses #525.

Move user input state out of `<DateInput/>` and into either `<DateRangePickerInputController/>` or `<SingleDatePicker/>`, passing down the value and a setter as props.