### PR TITLE
Recompute modifiers on date change, not just focus change

### DIFF
--- a/src/components/DayPickerRangeController.jsx
+++ b/src/components/DayPickerRangeController.jsx
@@ -464,7 +464,7 @@ export default class DayPickerRangeController extends React.PureComponent {
       }
     }
 
-    if (didFocusChange || recomputePropModifiers) {
+    if (didFocusChange || didStartDateChange || didEndDateChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = getPooledMoment(day);

--- a/src/components/DayPickerSingleDateController.jsx
+++ b/src/components/DayPickerSingleDateController.jsx
@@ -303,7 +303,7 @@ export default class DayPickerSingleDateController extends React.PureComponent {
       modifiers = this.addModifier(modifiers, date, 'selected');
     }
 
-    if (didFocusChange || recomputePropModifiers) {
+    if (didFocusChange || didDateChange || recomputePropModifiers) {
       values(visibleDays).forEach((days) => {
         Object.keys(days).forEach((day) => {
           const momentObj = getPooledMoment(day);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -882,6 +882,7 @@ describe('DayPickerRangeController', () => {
                 expect(visibleDays[monthString][dateString]).to.include('blocked-minimum-nights');
                 day.add(1, 'day');
               }
+          });
             });
 
             it('updates state to include `blocked` on the appropriate days', () => {
@@ -912,7 +913,7 @@ describe('DayPickerRangeController', () => {
       });
 
       describe('blocked-out-of-range', () => {
-        describe('focusedInput did not change', () => {
+        describe('focusedInput, startDate, endDate did not change', () => {
           it('does not call isOutsideRange if unchanged', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController
@@ -938,7 +939,7 @@ describe('DayPickerRangeController', () => {
           });
         });
 
-        describe('focusedInput changed', () => {
+        describe('focusedInput, startDate, endDate changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -952,13 +953,37 @@ describe('DayPickerRangeController', () => {
             };
           });
 
-          it('calls isOutsideRange for every visible day', () => {
+          it('calls isOutsideRange for every visible day when focusedInput changes', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isOutsideRange for every visible day when startDate changes', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              startDate: today,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isOutsideRange for every visible day when endDate changes', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              endDate: today,
               isOutsideRange: isOutsideRangeStub,
             });
             expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
@@ -995,7 +1020,7 @@ describe('DayPickerRangeController', () => {
       });
 
       describe('blocked-calendar', () => {
-        describe('focusedInput did not change', () => {
+        describe('focusedInput, startDate, endDate did not change', () => {
           it('does not call isDayBlocked if unchanged', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController
@@ -1021,7 +1046,7 @@ describe('DayPickerRangeController', () => {
           });
         });
 
-        describe('focusedInput changed', () => {
+        describe('focusedInput, startDate, endDate changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -1035,13 +1060,37 @@ describe('DayPickerRangeController', () => {
             };
           });
 
-          it('calls isDayBlocked for every visible day', () => {
+          it('calls isDayBlocked for every visible day when focusedInput changes', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
+              isDayBlocked: isDayBlockedStub,
+            });
+            expect(isDayBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayBlocked for every visible day when startDate changes', () => {
+            const isDayBlockedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              startDate: today,
+              isDayBlocked: isDayBlockedStub,
+            });
+            expect(isDayBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayBlocked for every visible day when endDate changes', () => {
+            const isDayBlockedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              endDate: today,
               isDayBlocked: isDayBlockedStub,
             });
             expect(isDayBlockedStub.callCount).to.equal(numVisibleDays);
@@ -1078,7 +1127,7 @@ describe('DayPickerRangeController', () => {
       });
 
       describe('highlighted-calendar', () => {
-        describe('focusedInput did not change', () => {
+        describe('focusedInput, startDate, endDate did not change', () => {
           it('does not call isDayHighlighted', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController
@@ -1104,7 +1153,7 @@ describe('DayPickerRangeController', () => {
           });
         });
 
-        describe('focusedInput changed', () => {
+        describe('focusedInput, startDate, endDate changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -1118,13 +1167,37 @@ describe('DayPickerRangeController', () => {
             };
           });
 
-          it('calls isDayHighlighted for every visible day', () => {
+          it('calls isDayHighlighted for every visible day when focusedInput changes', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerRangeController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focusedInput: END_DATE,
+              isDayHighlighted: isDayHighlightedStub,
+            });
+            expect(isDayHighlightedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayHighlighted for every visible day when startDate changes', () => {
+            const isDayHighlightedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              startDate: today,
+              isDayHighlighted: isDayHighlightedStub,
+            });
+            expect(isDayHighlightedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayHighlighted for every visible day when endDate changes', () => {
+            const isDayHighlightedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerRangeController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              endDate: today,
               isDayHighlighted: isDayHighlightedStub,
             });
             expect(isDayHighlightedStub.callCount).to.equal(numVisibleDays);

--- a/test/components/DayPickerRangeController_spec.jsx
+++ b/test/components/DayPickerRangeController_spec.jsx
@@ -882,7 +882,6 @@ describe('DayPickerRangeController', () => {
                 expect(visibleDays[monthString][dateString]).to.include('blocked-minimum-nights');
                 day.add(1, 'day');
               }
-          });
             });
 
             it('updates state to include `blocked` on the appropriate days', () => {

--- a/test/components/DayPickerSingleDateController_spec.jsx
+++ b/test/components/DayPickerSingleDateController_spec.jsx
@@ -119,7 +119,7 @@ describe('DayPickerSingleDateController', () => {
       });
 
       describe('blocked', () => {
-        describe('props.focused did not change', () => {
+        describe('props.focused and props.date did not change', () => {
           it('does not call isBlocked', () => {
             const isBlockedStub = sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
@@ -131,7 +131,7 @@ describe('DayPickerSingleDateController', () => {
           });
         });
 
-        describe('props.focused changed', () => {
+        describe('props.focused or props.date changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -145,7 +145,7 @@ describe('DayPickerSingleDateController', () => {
             };
           });
 
-          it('calls isBlocked for every visible day', () => {
+          it('calls isBlocked for every visible day when props.focused changes', () => {
             const isBlockedStub = sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked');
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
@@ -153,6 +153,18 @@ describe('DayPickerSingleDateController', () => {
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focused: true,
+            });
+            expect(isBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isBlocked for every visible day when props.date changes', () => {
+            const isBlockedStub = sinon.stub(DayPickerSingleDateController.prototype, 'isBlocked');
+            const wrapper = shallow(<DayPickerSingleDateController {...props} />);
+            wrapper.setState({ visibleDays });
+            isBlockedStub.reset();
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              date: today,
             });
             expect(isBlockedStub.callCount).to.equal(numVisibleDays);
           });
@@ -186,7 +198,7 @@ describe('DayPickerSingleDateController', () => {
       });
 
       describe('blocked-out-of-range', () => {
-        describe('props.focused did not change', () => {
+        describe('props.focused and props.date did not change', () => {
           it('does not call isOutsideRange if unchanged', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow((
@@ -214,7 +226,7 @@ describe('DayPickerSingleDateController', () => {
           });
         });
 
-        describe('props.focused changed', () => {
+        describe('props.focused or props.date changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -228,13 +240,25 @@ describe('DayPickerSingleDateController', () => {
             };
           });
 
-          it('calls isOutsideRange for every visible day', () => {
+          it('calls isOutsideRange for every visible day when props.focused changes', () => {
             const isOutsideRangeStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focused: true,
+              isOutsideRange: isOutsideRangeStub,
+            });
+            expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isOutsideRange for every visible day when props.date changes', () => {
+            const isOutsideRangeStub = sinon.stub();
+            const wrapper = shallow(<DayPickerSingleDateController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              date: today,
               isOutsideRange: isOutsideRangeStub,
             });
             expect(isOutsideRangeStub.callCount).to.equal(numVisibleDays);
@@ -283,7 +307,7 @@ describe('DayPickerSingleDateController', () => {
       });
 
       describe('blocked-calendar', () => {
-        describe('props.focused did not change', () => {
+        describe('props.focused and props.date did not change', () => {
           it('does not call isDayBlocked if unchanged', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController
@@ -309,7 +333,7 @@ describe('DayPickerSingleDateController', () => {
           });
         });
 
-        describe('props.focused changed', () => {
+        describe('props.focused or props.date changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -323,13 +347,25 @@ describe('DayPickerSingleDateController', () => {
             };
           });
 
-          it('calls isDayBlocked for every visible day', () => {
+          it('calls isDayBlocked for every visible day when props.focused changes', () => {
             const isDayBlockedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focused: true,
+              isDayBlocked: isDayBlockedStub,
+            });
+            expect(isDayBlockedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayBlocked for every visible day when props.date changes', () => {
+            const isDayBlockedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerSingleDateController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              date: today,
               isDayBlocked: isDayBlockedStub,
             });
             expect(isDayBlockedStub.callCount).to.equal(numVisibleDays);
@@ -366,7 +402,7 @@ describe('DayPickerSingleDateController', () => {
       });
 
       describe('highlighted-calendar', () => {
-        describe('focusedInput did not change', () => {
+        describe('props.focused and props.date did not change', () => {
           it('does not call isDayHighlighted if unchanged', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController
@@ -392,7 +428,7 @@ describe('DayPickerSingleDateController', () => {
           });
         });
 
-        describe('focusedInput changed', () => {
+        describe('props.focused or props.date changed', () => {
           const numVisibleDays = 3;
           let visibleDays;
           beforeEach(() => {
@@ -406,13 +442,25 @@ describe('DayPickerSingleDateController', () => {
             };
           });
 
-          it('calls isDayHighlighted for every visible day', () => {
+          it('calls isDayHighlighted for every visible day when props.focused changes', () => {
             const isDayHighlightedStub = sinon.stub();
             const wrapper = shallow(<DayPickerSingleDateController {...props} />);
             wrapper.setState({ visibleDays });
             wrapper.instance().componentWillReceiveProps({
               ...props,
               focused: true,
+              isDayHighlighted: isDayHighlightedStub,
+            });
+            expect(isDayHighlightedStub.callCount).to.equal(numVisibleDays);
+          });
+
+          it('calls isDayHighlighted for every visible day when props.date changes', () => {
+            const isDayHighlightedStub = sinon.stub();
+            const wrapper = shallow(<DayPickerSingleDateController {...props} />);
+            wrapper.setState({ visibleDays });
+            wrapper.instance().componentWillReceiveProps({
+              ...props,
+              date: today,
               isDayHighlighted: isDayHighlightedStub,
             });
             expect(isDayHighlightedStub.callCount).to.equal(numVisibleDays);


### PR DESCRIPTION
(Re-filing because I seem to have majorly screwed something up in Git CLI 😓)

Addresses #570.

Currently, block / range related modifiers are only recomputed when the currently focused input changes. However, this causes some issues when more complex block / range functions are used, e.g. those that make selectable dates conditional on current state.

This commit gives one potential fix, which is to recompute modifiers not just on focus change, but also on start / end date change. This DOES result in a slight perf cost because modifiers are computed more frequently; however from my experience perf bottlenecks have mainly arisen on month changes (where 30 new days are added and recomputed) and on hover changes (fixed in v11.x), not on selection change.

The added story gives an example of a case where range modifier computation does not work as expected. The added wrapper component has the following validation: start dates must be no earlier than 1 week after selected end date, and end dates must be no later than 1 week after selected start date. Without the change in `DayPickerRangeController`, the following actions lead to a bug:

1. Pick a start date. Note the modifiers correctly recompute after the end date is focused.
2. Click on a date BEFORE the start date. `react-dates` behavior is to change the currently selected start date. However, note that the modifiers DO NOT recompute.

Additionally, there is a similar bug when `keepOpenOnDateSelect` is enabled, which is more noticeable with the `SingleDatePicker`. Because modifiers recompute when the focused input toggles between `null` and the input, modifiers are never recomputed until the calendar is closed and reopened. The story in `SingleDatePicker` showcases this -- when the change in `SingleDatePicker.jsx` is undone, the modifier never recomputes.

If this change seems ok I'll delete the changes to unrelated files, and add test cases. Thanks!