### PR TITLE
Add after hovered start span class name

### DIFF
--- a/src/components/CalendarDay.jsx
+++ b/src/components/CalendarDay.jsx
@@ -117,6 +117,7 @@ class CalendarDay extends React.Component {
       useDefaultCursor,
       selected,
       hoveredSpan,
+      afterHoveredStartSpan,
       isOutsideRange,
       ariaLabel,
     } = getCalendarDaySettings(day, ariaLabelFormat, daySize, modifiers, phrases);
@@ -136,6 +137,7 @@ class CalendarDay extends React.Component {
           modifiers.has('blocked-minimum-nights') && styles.CalendarDay__blocked_minimum_nights,
           modifiers.has('blocked-calendar') && styles.CalendarDay__blocked_calendar,
           hoveredSpan && styles.CalendarDay__hovered_span,
+          afterHoveredStartSpan && styles.CalendarDay__after_hovered_start_span,
           modifiers.has('selected-span') && styles.CalendarDay__selected_span,
           modifiers.has('last-in-range') && styles.CalendarDay__last_in_range,
           modifiers.has('selected-start') && styles.CalendarDay__selected_start,
@@ -335,4 +337,5 @@ export default withStyles(({ reactDates: { color, font } }) => ({
   CalendarDay__today: {},
   CalendarDay__firstDayOfWeek: {},
   CalendarDay__lastDayOfWeek: {},
+  CalendarDay__after_hovered_start_span: {},
 }))(CalendarDay);

--- a/src/utils/getCalendarDaySettings.js
+++ b/src/utils/getCalendarDaySettings.js
@@ -30,6 +30,9 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
     || modifiers.has('after-hovered-start')
   );
 
+  const afterHoveredStartSpan = !selected &&
+    modifiers.has('after-hovered-start');
+
   const isOutsideRange = modifiers.has('blocked-out-of-range');
 
   const formattedDate = { date: day.format(ariaLabelFormat) };
@@ -46,6 +49,7 @@ export default function getCalendarDaySettings(day, ariaLabelFormat, daySize, mo
     useDefaultCursor,
     selected,
     hoveredSpan,
+    afterHoveredStartSpan,
     isOutsideRange,
     ariaLabel,
   };

--- a/test/utils/getCalendarDaySettings_spec.js
+++ b/test/utils/getCalendarDaySettings_spec.js
@@ -117,7 +117,7 @@ describe('getCalendarDaySettings', () => {
     });
 
     it('should be true when day is not selected and after-hovered-start', () => {
-      const modifiers = new Set(['hovered-span']);
+      const modifiers = new Set(['after-hovered-start']);
       const { hoveredSpan } = getCalendarDaySettings(
         testDay,
         testAriaLabelFormat,
@@ -145,6 +145,40 @@ describe('getCalendarDaySettings', () => {
           testPhrases,
         );
         expect(hoveredSpan).to.equal(false);
+      });
+    });
+  });
+
+  describe('afterHoveredStartSpan', () => {
+    it('should be true when day is not selected and after-hovered-start', () => {
+      const modifiers = new Set(['after-hovered-start']);
+      const { afterHoveredStartSpan } = getCalendarDaySettings(
+        testDay,
+        testAriaLabelFormat,
+        testDaySize,
+        modifiers,
+        testPhrases,
+      );
+      expect(afterHoveredStartSpan).to.equal(true);
+    });
+
+    it('should be false when day is some kind of selected', () => {
+      const selectedModifiers = new Set([
+        'selected',
+        'selected-start',
+        'selected-end',
+      ]);
+
+      selectedModifiers.forEach((selectedModifier) => {
+        const modifiers = new Set([selectedModifier]);
+        const { afterHoveredStartSpan } = getCalendarDaySettings(
+          testDay,
+          testAriaLabelFormat,
+          testDaySize,
+          modifiers,
+          testPhrases,
+        );
+        expect(afterHoveredStartSpan).to.equal(false);
       });
     });
   });


### PR DESCRIPTION
Hey, I know this is a bit half baked but wanted to check if you'd be interested in merging it before I update the docs, etc.? As mentioned in #1025, we don't want the minimum nights to have the hovered style when hovering the selected start date. Adding this class name allows us to style those days the same as when the start date is not hovered.