### PR TITLE
Updated README for SingleDatePicker's inputIconPosition prop values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,30 +19,35 @@ For examples of the datepicker in action, go to http://airbnb.io/react-dates.
 OR
 
 To run that demo on your own computer:
-* Clone this repository
-* `npm install`
-* `npm run storybook`
-* Visit http://localhost:6006/
+
+- Clone this repository
+- `npm install`
+- `npm run storybook`
+- Visit http://localhost:6006/
 
 ## Getting Started
+
 ### Install dependencies
+
 Ensure packages are installed with correct version numbers by running:
-  ```sh
-  (
-    export PKG=react-dates;
-    npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g; s/ *//g' | xargs npm install --save "$PKG"
-  )
-  ```
 
-  Which produces and runs a command like:
+```sh
+(
+  export PKG=react-dates;
+  npm info "$PKG" peerDependencies --json | command sed 's/[\{\},]//g ; s/: /@/g; s/ *//g' | xargs npm install --save "$PKG"
+)
+```
 
-  ```sh
-  npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.##
-  ```
+Which produces and runs a command like:
+
+```sh
+npm install --save react-dates moment@>=#.## react@>=#.## react-dom@>=#.##
+```
 
 ### Initialize
+
 ```js
-import 'react-dates/initialize';
+import "react-dates/initialize";
 ```
 
 As of v13.0.0 of `react-dates`, this project relies on `react-with-styles`. If you want to continue using CSS stylesheets and classes, there is a little bit of extra set-up required to get things going. As such, you need to import `react-dates/initialize` to set up class names on our components. This import should go at the top of your application as you won't be able to import any `react-dates` components without it.
@@ -50,30 +55,41 @@ As of v13.0.0 of `react-dates`, this project relies on `react-with-styles`. If y
 Note: This component assumes `box-sizing: border-box` is set globally in your page's CSS.
 
 ### Include component
+
 ```js
-import { DateRangePicker, SingleDatePicker, DayPickerRangeController } from 'react-dates';
+import {
+  DateRangePicker,
+  SingleDatePicker,
+  DayPickerRangeController
+} from "react-dates";
 ```
 
 #### Webpack
+
 Using Webpack with CSS loader, add the following import to your app:
+
 ```js
-import 'react-dates/lib/css/_datepicker.css';
+import "react-dates/lib/css/_datepicker.css";
 ```
 
 #### Without Webpack:
+
 Create a CSS file with the contents of `require.resolve('react-dates/lib/css/_datepicker.css')` and include it in your html `<head>` section.
 
 To see this in action, you can check out https://github.com/majapw/react-dates-demo which adds `react-dates` on top of a simple `create-react-app` setup.
 
 #### Overriding Base Class
-By default `react-dates` will use `PureComponent` conditionally if it is available.  However, it is possible to override this setting and use `Component` and `shouldComponentUpdate` instead. It is also possible to override the logic in `build/util/baseClass` if you know that you are using a React version with `PureComponent`.
-  ```javascript
-    import React from 'react';
-    export default React.PureComponent;
-    export const pureComponentAvailable = true;
-  ```
+
+By default `react-dates` will use `PureComponent` conditionally if it is available. However, it is possible to override this setting and use `Component` and `shouldComponentUpdate` instead. It is also possible to override the logic in `build/util/baseClass` if you know that you are using a React version with `PureComponent`.
+
+```javascript
+import React from "react";
+export default React.PureComponent;
+export const pureComponentAvailable = true;
+```
 
 #### Overriding styles
+
 Right now, the easiest way to tweak `react-dates` to your heart's content is to create another stylesheet to override the default react-dates styles. For example, you could create a file named `react_dates_overrides.css` with the following contents (Make sure when you import said file to your `app.js`, you import it after the `react-dates` styles):
 
 ```css
@@ -114,26 +130,31 @@ We provide a handful of components for your use. If you supply essential props t
 how to properly wrap the pickers in the [examples folder](https://github.com/airbnb/react-dates/tree/master/examples).
 
 #### DateRangePicker
+
 The `DateRangePicker` is a fully controlled component that allows users to select a date range. You can control the selected
 dates using the `startDate`, `endDate`, and `onDatesChange` props as shown below. The `DateRangePicker` also manages internal
 state for partial dates entered by typing (although `onDatesChange` will not trigger until a date has been entered
 completely in that case). Similarly, you can control which input is focused as well as calendar visibility (the calendar is
 only visible if `focusedInput` is defined) with the `focusedInput` and `onFocusChange` props as shown below.
 
-Here is the minimum *REQUIRED* setup you need to get the `DateRangePicker` working:
+Here is the minimum _REQUIRED_ setup you need to get the `DateRangePicker` working:
+
 ```jsx
 <DateRangePicker
   startDate={this.state.startDate} // momentPropTypes.momentObj or null,
   startDateId="your_unique_start_date_id" // PropTypes.string.isRequired,
   endDate={this.state.endDate} // momentPropTypes.momentObj or null,
   endDateId="your_unique_end_date_id" // PropTypes.string.isRequired,
-  onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
+  onDatesChange={({ startDate, endDate }) =>
+    this.setState({ startDate, endDate })
+  } // PropTypes.func.isRequired,
   focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
   onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
 />
 ```
 
-The following is a list of other *OPTIONAL* props you may provide to the `DateRangePicker` to customize appearance and behavior to your heart's desire. All constants (indicated by `ALL_CAPS`) are provided as named exports in `react-dates/constants`. Please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+The following is a list of other _OPTIONAL_ props you may provide to the `DateRangePicker` to customize appearance and behavior to your heart's desire. All constants (indicated by `ALL_CAPS`) are provided as named exports in `react-dates/constants`. Please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DRP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+
 ```js
 // input related props
 startDatePlaceholderText: PropTypes.string,
@@ -199,13 +220,15 @@ dayAriaLabelFormat: PropTypes.string,
 ```
 
 #### SingleDatePicker
+
 The `SingleDatePicker` is a fully controlled component that allows users to select a single date. You can control the selected
 date using the `date` and `onDateChange` props as shown below. The `SingleDatePicker` also manages internal
 state for partial dates entered by typing (although `onDateChange` will not trigger until a date has been entered
 completely in that case). Similarly, you can control whether or not the input is focused (calendar visibility is also
 controlled with the same props) with the `focused` and `onFocusChange` props as shown below.
 
-Here is the minimum *REQUIRED* setup you need to get the `SingleDatePicker` working:
+Here is the minimum _REQUIRED_ setup you need to get the `SingleDatePicker` working:
+
 ```jsx
 <SingleDatePicker
   date={this.state.date} // momentPropTypes.momentObj or null
@@ -216,7 +239,8 @@ Here is the minimum *REQUIRED* setup you need to get the `SingleDatePicker` work
 />
 ```
 
-The following is a list of other *OPTIONAL* props you may provide to the `SingleDatePicker` to customize appearance and behavior to your heart's desire. All constants (indicated by `ALL_CAPS`) are provided as named exports in `react-dates/constants`. Please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+The following is a list of other _OPTIONAL_ props you may provide to the `SingleDatePicker` to customize appearance and behavior to your heart's desire. All constants (indicated by `ALL_CAPS`) are provided as named exports in `react-dates/constants`. Please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=SDP%20-%20Input%20Props&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+
 ```js
 // input related props
 placeholder: PropTypes.string,
@@ -228,7 +252,7 @@ showClearDate: PropTypes.bool,
 customCloseIcon: PropTypes.node,
 showDefaultInputIcon: PropTypes.bool,
 customInputIcon: PropTypes.node,
-inputIconPosition: PropTypes.oneOf([ICON_BEFORE_POSITION, ICON_AFTER_POSITION]),
+inputIconPosition: PropTypes.oneOf(['before', 'after']),
 noBorder: PropTypes.bool,
 block: PropTypes.bool,
 small: PropTypes.bool,
@@ -279,22 +303,27 @@ dayAriaLabelFormat: PropTypes.string,
 ```
 
 #### DayPickerRangeController
+
 The `DayPickerRangeController` is a calendar-only version of the `DateRangePicker`. There are no inputs (which also means
 that currently, it is not keyboard accessible) and the calendar is always visible, but you can select a date range much in the same way you would with the `DateRangePicker`. You can control the selected
 dates using the `startDate`, `endDate`, and `onDatesChange` props as shown below. Similarly, you can control which input is focused with the `focusedInput` and `onFocusChange` props as shown below. The user will only be able to select a date if `focusedInput` is provided.
 
-Here is the minimum *REQUIRED* setup you need to get the `DayPickerRangeController` working:
+Here is the minimum _REQUIRED_ setup you need to get the `DayPickerRangeController` working:
+
 ```jsx
 <DayPickerRangeController
   startDate={this.state.startDate} // momentPropTypes.momentObj or null,
   endDate={this.state.endDate} // momentPropTypes.momentObj or null,
-  onDatesChange={({ startDate, endDate }) => this.setState({ startDate, endDate })} // PropTypes.func.isRequired,
+  onDatesChange={({ startDate, endDate }) =>
+    this.setState({ startDate, endDate })
+  } // PropTypes.func.isRequired,
   focusedInput={this.state.focusedInput} // PropTypes.oneOf([START_DATE, END_DATE]) or null,
   onFocusChange={focusedInput => this.setState({ focusedInput })} // PropTypes.func.isRequired,
 />
 ```
 
-The following is a list of other *OPTIONAL* props you may provide to the `DayPickerRangeController` to customize appearance and behavior to your heart's desire. Again, please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DayPickerRangeController&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+The following is a list of other _OPTIONAL_ props you may provide to the `DayPickerRangeController` to customize appearance and behavior to your heart's desire. Again, please explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DayPickerRangeController&selectedStory=default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for more information on what each of these props do.
+
 ```js
   // calendar presentation and interaction related props
   enableOutsideDays: PropTypes.bool,
@@ -336,7 +365,7 @@ The following is a list of other *OPTIONAL* props you may provide to the `DayPic
 [Moment.js](http://momentjs.com) is a peer dependency of `react-dates`. The latter then uses a single instance of `moment` which is imported in one’s project. Loading a locale is done by calling `moment.locale(..)` in the component where `moment` is imported, with the [locale key](http://momentjs.com/docs/#/i18n/) of choice. For instance:
 
 ```js
-moment.locale('pl'); // Polish
+moment.locale("pl"); // Polish
 ```
 
 However, this only solves date localization. For complete internationalization of the components, `react-dates` defines a certain amount of [user interface strings](https://github.com/airbnb/react-dates/blob/master/src/defaultPhrases.js) in English which can be changed through the `phrases` prop (explore the [storybook](http://airbnb.io/react-dates/?selectedKind=DateRangePicker%20%28DRP%29&selectedStory=non-english%20locale&full=0&addons=1&stories=1&panelRight=0&addonPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel) for examples). For accessibility and usability concerns, **all these UI elements should be translated**.
@@ -348,23 +377,26 @@ However, this only solves date localization. For complete internationalization o
 ### Interfaces
 
 The `react-dates/initialize` script actually relies on [react-with-styles-interface-css](https://github.com/airbnb/react-with-styles-interface-css) under the hood. If you are interested in a different solution for styling in your project, you can do your own initialization of a another [interface](https://github.com/airbnb/react-with-styles/blob/master/README.md#interfaces). At Airbnb, for instance, we rely on [Aphrodite](https://github.com/Khan/aphrodite) under the hood and therefore use the Aphrodite interface for `react-with-styles`. If you want to do the same, you would use the following pattern:
+
 ```js
-import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
-import aphroditeInterface from 'react-with-styles-interface-aphrodite';
-import DefaultTheme from 'react-dates/lib/theme/DefaultTheme';
+import ThemedStyleSheet from "react-with-styles/lib/ThemedStyleSheet";
+import aphroditeInterface from "react-with-styles-interface-aphrodite";
+import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 
 ThemedStyleSheet.registerInterface(aphroditeInterface);
 ThemedStyleSheet.registerTheme(DefaultTheme);
 ```
 
-The above code has to be run before any `react-dates` component is imported. Otherwise, you will get an error. Also note that if you register any custom interface manually, you *must* also manually register a theme.
+The above code has to be run before any `react-dates` component is imported. Otherwise, you will get an error. Also note that if you register any custom interface manually, you _must_ also manually register a theme.
 
 ### Theming
+
 `react-dates` also now supports a different way to theme. You can see the default theme values in [this file](https://github.com/airbnb/react-dates/blob/master/src/theme/DefaultTheme.js) and you would override them in the following manner:
+
 ```js
-import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
-import aphroditeInterface from 'react-with-styles-interface-aphrodite';
-import DefaultTheme from 'react-dates/lib/theme/DefaultTheme';
+import ThemedStyleSheet from "react-with-styles/lib/ThemedStyleSheet";
+import aphroditeInterface from "react-with-styles-interface-aphrodite";
+import DefaultTheme from "react-dates/lib/theme/DefaultTheme";
 
 ThemedStyleSheet.registerInterface(aphroditeInterface);
 ThemedStyleSheet.registerTheme({
@@ -373,21 +405,22 @@ ThemedStyleSheet.registerTheme({
     color: {
       ...DefaultTheme.reactDates.color,
       highlighted: {
-        backgroundColor: '#82E0AA',
-        backgroundColor_active: '#58D68D',
-        backgroundColor_hover: '#58D68D',
-        color: '#186A3B',
-        color_active: '#186A3B',
-        color_hover: '#186A3B',
-      },
-    },
-  },
+        backgroundColor: "#82E0AA",
+        backgroundColor_active: "#58D68D",
+        backgroundColor_hover: "#58D68D",
+        color: "#186A3B",
+        color_active: "#186A3B",
+        color_hover: "#186A3B"
+      }
+    }
+  }
 });
 ```
 
-The above code would use shades of green instead of shades of yellow for the highlight color on `CalendarDay` components. Note that you *must* register an interface if you manually register a theme. One will not work without the other.
+The above code would use shades of green instead of shades of yellow for the highlight color on `CalendarDay` components. Note that you _must_ register an interface if you manually register a theme. One will not work without the other.
 
 #### A note on using `react-with-styles-interface-css`
+
 The default interface that `react-dates` ships with is the [CSS interface](https://github.com/airbnb/react-with-styles-interface-css). If you want to use this interface along with the theme registration method, you will need to rebuild the core `_datepicker.css` file. We do not currently expose a utility method to build this file, but you can follow along with the code in https://github.com/airbnb/react-dates/blob/master/scripts/buildCSS.js to build your own custom themed CSS file.
 
 [package-url]: https://npmjs.org/package/react-dates


### PR DESCRIPTION
Previous values of 'ICON_BEFORE_POSITION' & 'ICON_AFTER_POSITION' did not work when passed to the component. I've updated the values to 'before' and 'after' which displays the expected results. 